### PR TITLE
SpringJobScheduler报already been defined问题

### DIFF
--- a/spring-boot-elastic-job-starter/src/main/java/com/cxytiandi/elasticjob/parser/JobConfParser.java
+++ b/spring-boot-elastic-job-starter/src/main/java/com/cxytiandi/elasticjob/parser/JobConfParser.java
@@ -148,8 +148,8 @@ public class JobConfParser implements ApplicationContextAware {
             
             factory.addConstructorArgValue(elasticJobListeners);
             DefaultListableBeanFactory defaultListableBeanFactory = (DefaultListableBeanFactory)ctx.getAutowireCapableBeanFactory();
-			defaultListableBeanFactory.registerBeanDefinition("SpringJobScheduler", factory.getBeanDefinition());
-			SpringJobScheduler springJobScheduler = (SpringJobScheduler) ctx.getBean("SpringJobScheduler");
+			defaultListableBeanFactory.registerBeanDefinition(jobName+"SpringJobScheduler", factory.getBeanDefinition());
+			SpringJobScheduler springJobScheduler = (SpringJobScheduler) ctx.getBean(jobName+"SpringJobScheduler");
 			springJobScheduler.init();
 			logger.info("【" + jobName + "】\t" + jobClass + "\tinit success");
 		}


### PR DESCRIPTION
[issues-14](https://github.com/yinjihuan/elastic-job-spring-boot-starter/issues/14)，多Job情况下，报：A bean with that name has already been defined in null and overriding is disabled 问题处理